### PR TITLE
Fix copy paste error in evaluate_divergence_at_vertices' docstring

### DIFF
--- a/tutorial_completed.py
+++ b/tutorial_completed.py
@@ -646,7 +646,7 @@ def evaluate_divergence_at_vertices(F,l,v):
 
     :param F: |F|x3 vertex-face adjacency list F
     :param l: |F|x3 edge-lengths array, giving the length of each face-side
-    :param v: |F|x3 edge-lengths array, giving the length of each face-side
+    :param v: A vector function as a |F|x3 numpy array, holding one vector per face
     :returns: The divergences as a length-|V| numpy array
     """
 

--- a/tutorial_skeleton.py
+++ b/tutorial_skeleton.py
@@ -371,7 +371,7 @@ def evaluate_divergence_at_vertices(F,l,v):
 
     :param F: |F|x3 vertex-face adjacency list F
     :param l: |F|x3 edge-lengths array, giving the length of each face-side
-    :param v: |F|x3 edge-lengths array, giving the length of each face-side
+    :param v: A vector function as a |F|x3 numpy array, holding one vector per face
     :returns: The divergences as a length-|V| numpy array
     """
     raise ValueError("not yet implemented") 


### PR DESCRIPTION
Just a little fix to the docstring of `evaluate_divergence_at_vertices`!

Thanks for the course,
É.